### PR TITLE
Only add a -profile argument if one is not already present.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate log;
+#[macro_use] extern crate log;
 extern crate mozprofile;
 #[cfg(target_os = "windows")]
 extern crate winreg;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,5 +1,6 @@
 use mozprofile::prefreader::PrefReaderError;
 use mozprofile::profile::Profile;
+use std::ascii::AsciiExt;
 use std::convert::From;
 use std::env;
 use std::error::Error;
@@ -96,6 +97,8 @@ impl Runner for FirefoxRunner {
         let mut cmd = Command::new(&self.binary);
         self.build_command(&mut cmd);
 
+        debug!("Command {:?}", cmd);
+
         let prefs = try!(self.profile.user_prefs());
         try!(prefs.write());
 
@@ -112,9 +115,12 @@ impl Runner for FirefoxRunner {
         command
             .env("MOZ_NO_REMOTE", "1")
             .env("NO_EM_RESTART", "1")
-            .args(&self.args[..])
-            .arg("-profile").arg(&self.profile.path)
-            .stdout(Stdio::inherit())
+            .args(&self.args[..]);
+
+        if !self.args.iter().any(|x| is_profile_arg(x)) {
+            command.arg("-profile").arg(&self.profile.path);
+        }
+        command.stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
     }
 
@@ -123,15 +129,66 @@ impl Runner for FirefoxRunner {
     }
 
     fn stop(&mut self) -> IoResult<Option<process::ExitStatus>> {
-        match self.process.as_mut() {
-            Some(p) => {
-                try!(p.kill());
-                let status = try!(p.wait());
-                self.ret_code = Some(status);
-            },
-            None => {}
+        if let Some(p) = self.process.as_mut() {
+            try!(p.kill());
+            let status = try!(p.wait());
+            self.ret_code = Some(status);
         };
         Ok(self.ret_code)
+    }
+}
+
+fn parse_arg_name(arg: &str) -> Option<&str> {
+    let mut start = 0;
+    let mut end = 0;
+
+    for (i, c) in arg.chars().enumerate() {
+        if i == 0 {
+            if !platform::arg_prefix_char(c) {
+                break;
+            }
+        } else if i == 1 {
+            if name_end_char(c) {
+                break;
+            } else if c != '-' {
+                start = i;
+                end = start + 1;
+            } else {
+                start = i + 1;
+                end = start;
+            }
+        } else {
+            end += 1;
+            if name_end_char(c) {
+                end -= 1;
+                break;
+            }
+        }
+    }
+
+    if start > 0 && end > start {
+        Some(&arg[start..end])
+    } else {
+        None
+    }
+}
+
+fn name_end_char(c: char) -> bool {
+    c == ' ' || c == '='
+}
+
+/// Check if an argument string affects the Firefox profile
+///
+/// Returns a boolean indicating whether a given string
+/// contains one of the `-P`, `-Profile` or `-ProfileManager`
+/// arguments, respecting the various platform-specific conventions.
+pub fn is_profile_arg(arg: &str) -> bool {
+    if let Some(name) = parse_arg_name(arg) {
+        name.eq_ignore_ascii_case("profile") ||
+            name.eq_ignore_ascii_case("p") ||
+            name.eq_ignore_ascii_case("profilemanager")
+    } else {
+        false
     }
 }
 
@@ -156,6 +213,10 @@ pub mod platform {
 
     pub fn firefox_default_path() -> Option<PathBuf> {
         find_binary("firefox")
+    }
+
+    pub fn arg_prefix_char(c: char) -> bool {
+        c == '-'
     }
 }
 
@@ -183,6 +244,10 @@ pub mod platform {
             }
         }
         None
+    }
+
+    pub fn arg_prefix_char(c: char) -> bool {
+        c == '-'
     }
 }
 
@@ -234,6 +299,10 @@ pub mod platform {
         }
         Ok(None)
     }
+
+    pub fn arg_prefix_char(c: char) -> bool {
+        c == '/' || c == '-'
+    }
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
@@ -242,5 +311,66 @@ pub mod platform {
 
     pub fn firefox_default_path() -> Option<PathBuf> {
         None
+    }
+
+    pub fn arg_prefix_char(c: char) -> bool {
+        c == '-'
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_arg_name, is_profile_arg};
+
+    fn parse(arg: &str, name: Option<&str>) {
+        let result = parse_arg_name(arg);
+        assert_eq!(result, name);
+    }
+
+    #[test]
+    fn test_parse_arg_name() {
+        parse("-p", Some("p"));
+        parse("--p", Some("p"));
+        parse("--profile foo", Some("profile"));
+        parse("--profile", Some("profile"));
+        parse("--", None);
+        parse("", None);
+        parse("-=", None);
+        parse("--=", None);
+        parse("-- foo", None);
+        parse("foo", None);
+        parse("/ foo", None);
+        parse("/- foo", None);
+        parse("/=foo", None);
+        parse("foo", None);
+        parse("-profile", Some("profile"));
+        parse("-profile=foo", Some("profile"));
+        parse("-profile = foo", Some("profile"));
+        parse("-profile abc", Some("profile"));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_parse_arg_name_windows() {
+        parse("/profile", Some("profile"));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn test_parse_arg_name_non_windows() {
+        parse("/profile", None);
+    }
+
+    #[test]
+    fn test_is_profile_arg() {
+        assert!(is_profile_arg("--profile"));
+        assert!(is_profile_arg("-p"));
+        assert!(is_profile_arg("-PROFILEMANAGER"));
+        assert!(is_profile_arg("-ProfileMANAGER"));
+        assert!(!is_profile_arg("-- profile"));
+        assert!(!is_profile_arg("-profiled"));
+        assert!(!is_profile_arg("-p1"));
+        assert!(is_profile_arg("-p test"));
+        assert!(is_profile_arg("-profile /foo"));
     }
 }


### PR DESCRIPTION
Previously we unconditionally added a -profile argument. Instead we
should do this only if there is not a user-supplied profile.